### PR TITLE
Adapt calculation of jumper addresses

### DIFF
--- a/Unit/Unit.ino
+++ b/Unit/Unit.ino
@@ -280,7 +280,7 @@ void requestEvent() {
 
 //returns the adress of the unit as int from 0-15
 int getaddress() {
-  int address = !digitalRead(ADRESSSW4) + (!digitalRead(ADRESSSW3) * 2) + (!digitalRead(ADRESSSW2) * 4) + (!digitalRead(ADRESSSW1) * 8);
+  int address = !digitalRead(ADRESSSW1) + (!digitalRead(ADRESSSW2) * 2) + (!digitalRead(ADRESSSW3) * 4) + (!digitalRead(ADRESSSW4) * 8);
   return address;
 }
 


### PR DESCRIPTION
The order of the the address calculation is adapter for the jumpers. This aligns the calculation to the wording ADDRESSW1 to ADDRESSW4 as well as the physical PCB design.

Closes codingcatgirl/split-flap-fae-pcb#2